### PR TITLE
Tweak to nodecg-utility-obs to support transition outside of studio mode

### DIFF
--- a/packages/nodecg-utility-obs/src/index.ts
+++ b/packages/nodecg-utility-obs/src/index.ts
@@ -189,7 +189,7 @@ export class OBSUtility extends OBSWebSocket {
 					try {
 						await this.send('SetCurrentTransition', { "transition-name": name });
 					} catch (error) {
-						log.error('Error setting scene for transition:', error);
+						log.error('Error setting current transition:', error);
 						if (callback && !callback.handled) {
 							callback(error);
 						}
@@ -201,7 +201,7 @@ export class OBSUtility extends OBSWebSocket {
 					try {
 						await this.send('SetTransitionDuration', { duration: duration });
 					} catch (error) {
-						log.error('Error setting duration for transition:', error);
+						log.error('Error setting transition duration:', error);
 						if (callback && !callback.handled) {
 							callback(error);
 						}
@@ -210,6 +210,7 @@ export class OBSUtility extends OBSWebSocket {
 				}
 
 				try {
+					// Mark that we're starting to transition. Resets to false after SwitchScenes.
 					this.replicants.transitioning.value = true;
 					await this.send('SetCurrentScene', {'scene-name': sceneName});
 				} catch (error) {
@@ -465,7 +466,9 @@ export class OBSUtility extends OBSWebSocket {
 			'with-transition': transitionConfig
 		};
 
+		// Mark that we're starting to transition. Resets to false after SwitchScenes.
 		this.replicants.transitioning.value = true;
+
 		if (typeof this.hooks.preTransition === 'function') {
 			const modifiedTransitionOpts = await this.hooks.preTransition(clone(transitionOpts));
 			if (modifiedTransitionOpts) {

--- a/packages/nodecg-utility-obs/test/main.test.js
+++ b/packages/nodecg-utility-obs/test/main.test.js
@@ -115,7 +115,8 @@ test.cb('obs:previewScene failure', t => {
 	}, 0);
 });
 
-test.cb('obs:transition - without hook', t => {
+test.cb('obs:transition studio - without hook', t => {
+	t.context.obs.replicants.studioMode.value = true;
 	t.plan(4);
 
 	// Tell our #send stub to return a promise that resolves.
@@ -134,7 +135,8 @@ test.cb('obs:transition - without hook', t => {
 	}, 0);
 });
 
-test.cb('obs:transition - with sync hook', t => {
+test.cb('obs:transition studio - with sync hook', t => {
+	t.context.obs.replicants.studioMode.value = true;
 	t.plan(5);
 
 	// Tell our #transitionToProgram stub to return a promise that resolves.
@@ -157,7 +159,8 @@ test.cb('obs:transition - with sync hook', t => {
 	}, 0);
 });
 
-test.cb('obs:transition - with async hook', t => {
+test.cb('obs:transition studio - with async hook', t => {
+	t.context.obs.replicants.studioMode.value = true;
 	t.plan(5);
 
 	// Tell our #send stub to return a promise that resolves.
@@ -180,7 +183,8 @@ test.cb('obs:transition - with async hook', t => {
 	}, 0);
 });
 
-test.cb('obs:transition - with sceneName', t => {
+test.cb('obs:transition studio - with sceneName', t => {
+	t.context.obs.replicants.studioMode.value = true;
 	t.plan(4);
 
 	// Tell our stubs to return a promise that resolves.
@@ -196,6 +200,41 @@ test.cb('obs:transition - with sceneName', t => {
 		t.deepEqual(t.context.obs.send.secondCall.args, ['TransitionToProgram', {'with-transition': {name: 'transition-name', duration: 250}}]);
 		t.end();
 	}, 0);
+});
+
+test.cb('obs:transition non-studio - with sceneName', t => {
+	t.context.obs.replicants.studioMode.value = false;
+
+	// Tell our stubs to return a promise that resolves.
+	t.context.obs.send.resolves();
+
+	t.context.obs.replicants.websocket.value.status = 'connected';
+	t.context.nodecg.emit('obs:transition', { sceneName: 'Foo Scene'});
+
+	setTimeout(() => {
+		t.true(t.context.obs.replicants.transitioning.value);
+		t.deepEqual(t.context.obs.send.firstCall.args, ['SetCurrentScene', {'scene-name': 'Foo Scene'}]);
+		t.end()
+	});
+});
+
+test.cb('obs:transition non-studio - changes transition', t => {
+	t.context.obs.replicants.studioMode.value = false;
+
+	// Tell our stubs to return a promise that resolves.
+	t.context.obs.send.resolves();
+
+	t.context.obs.replicants.websocket.value.status = 'connected';
+	t.context.nodecg.emit('obs:transition', {name: 'transition-name', duration: 250, sceneName: 'Foo Scene'});
+
+	setTimeout(() => {
+		t.true(t.context.obs.replicants.transitioning.value);
+		t.true(t.context.obs.send.calledThrice);
+		t.deepEqual(t.context.obs.send.firstCall.args, ['SetCurrentTransition', {'transition-name': 'transition-name'}]);
+		t.deepEqual(t.context.obs.send.secondCall.args, ['SetTransitionDuration', {duration: 250}]);
+		t.deepEqual(t.context.obs.send.thirdCall.args, ['SetCurrentScene', {'scene-name': 'Foo Scene'}]);
+		t.end()
+	});
 });
 
 test.cb('obs:transition failure', t => {


### PR DESCRIPTION
Worked on a tweak to allow the obs:transition message to work when OBS is not in studio mode. Let me know if there are any changes you'd like to see in this branch, including alternative tests. I tested it locally as well as added a few unit tests, but I could have missed something.

I found that the dependencies could probably use some work, as typescript and nyc seem to be referred to in the base module but not in the sub module, so trying to run the test for the utility module directly didn't work without a global dependency. That said, I've never worked with lerna before.