### PR TITLE
fix(schemas): update schema for obs-websocket 4.8

### DIFF
--- a/packages/nodecg-utility-obs/schemas/types/obs_source.json
+++ b/packages/nodecg-utility-obs/schemas/types/obs_source.json
@@ -3,6 +3,9 @@
 	"type": "object",
 	"additionalProperties": false,
 	"properties": {
+		"alignment": {
+			"type": "number"
+		},
 		"cx": {
 			"type": "number"
 		},
@@ -13,6 +16,9 @@
 			"type": "number"
 		},
 		"locked": {
+			"type": "boolean"
+		},
+		"muted": {
 			"type": "boolean"
 		},
 		"name": {


### PR DESCRIPTION
I was getting this error over and over in the logs:

```
error: [moment:obs] Error updating program scene: 
{
  message: 'Invalid value rejected for replicant "obs:programScene" in namespace "moment":\n' +
    '\tField "data" no (or more than one) schemas match\n',
  stack: 'Error: Invalid value rejected for replicant "obs:programScene" in namespace "moment":\n' +
    '\tField "data" no (or more than one) schemas match\n' +
    '\n' +
    '    at Replicant.validate (/Volumes/Data/Media/Developer/Side Projects/Moment/moment-nodecg/lib/replicant/shared.js:296:12)\n' +
    '    at Replicant.set value [as value] (/Volumes/Data/Media/Developer/Side Projects/Moment/moment-nodecg/lib/replicant/replicant.js:34:8)\n' +
    '    at /Volumes/Data/Media/Developer/Side Projects/Moment/moment-nodecg/bundles/moment/node_modules/nodecg-utility-obs/dist/index.js:329:52\n' +
    '    at processTicksAndRejections (internal/process/task_queues.js:93:5)\n' +
    '    at async Promise.all (index 1)'
}
```

Was able to determine that it was due to some new properties added to the [obs-websocket spec](https://github.com/Palakis/obs-websocket/blob/4.8.0/docs/generated/protocol.md#sceneitem) in 4.8.0.

The spec doesn't list them as optional, but I didn't make them required so as not to break compatibility with earlier versions of obs-websocket.